### PR TITLE
Add color-scheme: dark

### DIFF
--- a/css_dark.css
+++ b/css_dark.css
@@ -171,3 +171,4 @@ textarea, select, input{background: #000 !important}
 .sc-classic .keyboardShortcuts__shortcutsGroup>dl>dt>kbd>kbd {background: #222222 !important; } /* Removing the white background in the "Keyboard Shortcuts" page*/
 .image__whiteOutline .image__full {border: 2px solid #161719 !important;} /* Removing the white borders from avatars in the stream page*/
 .sc-classic .artistShortcutTile__badge {border: 2px solid #161719 !important;} /* Removing the white borders from the orange icon near the "Latest from people you know" header*/
+:root {color-scheme: dark;} /* Adds a color-scheme to the site, making the scrollbar dark */


### PR DESCRIPTION
### Adds a color-scheme to the site, making the scrollbar dark.

Before:
![image](https://user-images.githubusercontent.com/19778952/203673701-72086297-bd32-49ec-bc58-b2a6ecb43edf.png)

After:
![image](https://user-images.githubusercontent.com/19778952/203673663-a7dc881a-55b1-4a1e-a10d-0925ffcd050b.png)
