### PR TITLE
Updated manifest to v3 and added "css" to content scripts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,26 +1,31 @@
 {
   "name": "DarkCloud",
   "description": "SoundCloud Dark Theme",
-  "version": "2023.11.07",
-  "permissions": [],
-  "icons": {"128": "darklogo.png" },
-  "background": {
-    "scripts": ["background.js"]
+  "version": "2024.07.30",
+  "permissions": ["scripting"],
+  "manifest_version": 3,
+  "icons": {
+    "128": "darklogo.png"
   },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_title": "DarkCloud",
+    "default_icon": "darklogo.png"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["css_dark.css"],
+      "matches": ["https://soundcloud.com/*"]
+    }
+  ],
   "content_scripts": [
     {
       "matches": ["https://soundcloud.com/*"],
       "js": ["background.js"],
+      "css": ["css_dark.css"],
       "run_at": "document_start"
     }
-  ],
-  "browser_action": {
-    "default_title": "DarkCloud",
-    "default_icon":"darklogo.png"
-  },
-
-  "manifest_version": 2,
-  "web_accessible_resources": [
-    "css_dark.css"
   ]
 }


### PR DESCRIPTION
I have noticed that the extension stopped working at least on my Chrome and it seems that updating the manifest to v3 and loading the "css_dark.css" in the "css" prop inside "content_scripts" fixes it, also changed the version in case this is approved, but I don't know if that's correct.
I am trying to resolve some CSS issues that are open, I will push them sooner!
I hope this helps! Please tell me if there's something wrong..