### PR TITLE
Fix background.js

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,4 +12,4 @@ setTimeout(() => {
     observer.observe(document, { childList: true, subtree: true });
 }, 0);
 
-window.addEventListener('load', () => void document.body.style.removeProperty('background'));
+window.addEventListener('load', () => void document.body.style.removeProperty('background'), { passive: true, once: true });

--- a/background.js
+++ b/background.js
@@ -4,8 +4,12 @@ link.rel  = 'stylesheet';
 link.type = 'text/css';
 link.href = chrome.extension.getURL('css_dark.css');
 
-document.head.appendChild(link);
-
 const observer = new MutationObserver(() => link.parentNode == null && document.head.appendChild(link));
 
-observer.observe(document, { childList: true, subtree: true });
+setTimeout(() => {
+    document.head.appendChild(link);
+    document.body.style.background = '#000';
+    observer.observe(document, { childList: true, subtree: true });
+}, 0);
+
+window.addEventListener('load', () => void document.body.style.removeProperty('background'));

--- a/background.js
+++ b/background.js
@@ -1,15 +1,11 @@
-window.addEventListener('DOMNodeRemoved', function() {
-  if (document.getElementById('darkstyle_css') == null) {
-    var head = document.getElementsByTagName('head')[0],
-      link = document.createElement('link');
+const link = document.createElement('link');
 
-    link.id     = 'darkstyle_css';
-    link.rel    = 'stylesheet';
-    link.type   = 'text/css';
-    link.href   = chrome.extension.getURL('css_dark.css');
-    link.media  = 'all';
+link.rel  = 'stylesheet';
+link.type = 'text/css';
+link.href = chrome.extension.getURL('css_dark.css');
 
-    head.appendChild(link);
-  }
-});
+document.head.appendChild(link);
 
+const observer = new MutationObserver(() => link.parentNode == null && document.head.appendChild(link));
+
+observer.observe(document, { childList: true, subtree: true });


### PR DESCRIPTION
fix for #40 as mentioned by @CTRPaul and me in #39 (which is only for updating the `manifest.json`)

replaced the [deprecated](https://developer.chrome.com/blog/mutation-events-deprecation) `DOMNodeRemoved` event with a `MutationObserver`

stores a reference to the created `link` element so it's only made once and re-added when it's removed from the DOM
